### PR TITLE
Wave 0 (P0): version fix, full plugin tarball, MCP prompts, doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,10 @@ project's `manifest.json`:
 - Cross-LLM specialist agents via bmad-method SKILL.md format (beta.3):
   Zara, Ray, Max installed to `.claude/skills/` + `.agents/skills/`
 - Unity project asset resources in MCP (`@Unity Prefabs`, `@Unity Materials`, etc.) (beta.3)
+- Workflow rules exposed as MCP prompts — `preflight`, `scene-interview`,
+  `session-handoff`, `shader-guide` — so every client receives them (beta.7)
+- `mosaic-mcp doctor` — one-command connection diagnostics (discovery file,
+  live editor, port, HMAC handshake, clock skew) (beta.7)
 - Apache 2.0 license with patent grant
 
 ### v1.0 stable

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Mosaic Bridge connects MCP-compliant AI clients — Claude Code, Claude Desktop,
 Cursor, Gemini CLI, and any other Model Context Protocol client — to a running
-Unity Editor. It exposes ~250 tools covering GameObject and scene operations,
+Unity Editor. It exposes 290 tools covering GameObject and scene operations,
 procedural generation, physics simulation, pathfinding, rendering, animation,
 and more.
 
@@ -139,6 +139,17 @@ convention — written to both `.claude/skills/` (Claude Code slash commands) an
 | Ray — Shader Expert | `/mosaic-shader` | `@mosaic-shader` | `$mosaic-shader` | ShaderGraph creation, node wiring, debugging |
 | Max — Scene Builder | `/mosaic-scene` | `@mosaic-scene` | `$mosaic-scene` | Full scene construction, particles, physics |
 
+The installer also copies four **workflows** into `.claude/workflows/`
+(`preflight`, `scene-plan`, `shader-guide`, `session-handoff`).
+
+### Workflow prompts (any MCP client)
+
+Beyond the instruction files, the MCP server exposes the same protocol rules as
+**MCP prompts**, so every client — not just ones with a `CLAUDE.md` — can pull
+them on demand: `preflight`, `scene-interview`, `session-handoff`, and
+`shader-guide`. In Claude Code they show up in the prompt picker; other clients
+list them via `prompts/list`.
+
 To skip writing instruction files:
 
 ```bash
@@ -180,7 +191,7 @@ Then point your MCP client at:
 
 ## What's inside
 
-~250 tools across 60+ categories. A sample:
+290 tools across 64 categories. A sample:
 
 | Category | Tools | Notable |
 |---|---|---|
@@ -290,6 +301,7 @@ registry:
 
 ```
 mosaic-mcp [options]
+mosaic-mcp doctor [options]  Diagnose the bridge connection and exit
 
   --project-path <path>     Unity project root (recommended)
   --project-hash <hash>     16-hex-char project hash
@@ -298,6 +310,43 @@ mosaic-mcp [options]
   -h, --help                Show help
   -v, --version             Show version
 ```
+
+---
+
+## Troubleshooting
+
+**Tools don't appear, or the client says the connection closed?** Run the
+built-in doctor — it checks every link in the chain and tells you exactly which
+one is broken:
+
+```bash
+npx @mosaicxr-ai/mcp-server doctor --project-path /path/to/UnityProject
+```
+
+A healthy bridge reports all green:
+
+```
+  ✓ Discovery file: Found and signed (…/bridge-discovery.json), Unity 6000.3.10f1, port 8282.
+  ✓ Live editor: 1 running Unity Editor (pid 56258, port 8282).
+  ✓ Port reachable: 127.0.0.1:8282 accepted a connection.
+  ✓ Health + HMAC: Bridge healthy — 265 tools, state Running.
+  ✓ Clock skew: System clock within tolerance of the bridge host.
+
+  Result: OK — the bridge is reachable.
+```
+
+Common failures and fixes:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `✗ Discovery file: No live Unity Editor detected` | Unity isn't open, or the project's bridge hasn't started | Open the project in the Editor, wait for compile, and check the Console for `Mosaic Bridge bootstrap complete` |
+| `✗ Discovery file: Not found at …/<hash>/` | Wrong `--project-path` (relative paths resolve against your shell's current dir) | Pass an **absolute** project path, or omit `--project-path` to auto-detect the single running Editor |
+| `✗ Health + HMAC: … 401` | The bridge rotated its secret on a domain reload | Restart your MCP client so it re-reads the discovery file |
+| `⚠ Live editor: N running editors` | Multiple Editors are open | Pass `--project-path` so the server targets the right one |
+| `⚠ Clock skew` | System clock differs from the bridge host | Sync the clock — large skew trips the HMAC timestamp window |
+
+With no `--project-path` and exactly one Editor open, `doctor` (and the server
+itself) auto-detects it — the simplest way to avoid path mistakes.
 
 ---
 
@@ -367,7 +416,7 @@ Monorepo layout:
 ```
 packages/
 ├── com.mosaic.bridge/       Unity UPM package (Editor + Runtime + Tests)
-│   ├── Editor/              ~250 tools + core infrastructure
+│   ├── Editor/              290 tools + core infrastructure
 │   ├── Runtime/             Runtime-compatible tool subset
 │   ├── Tests/               NUnit + Unity Test Runner
 │   └── Samples~/            Custom-tool authoring sample
@@ -388,7 +437,7 @@ project's `manifest.json`:
 ## Roadmap
 
 ### v1.0 beta (current)
-- Core bridge, MCP server, ~250 tools across 60+ categories
+- Core bridge, MCP server, 290 tools across 64 categories
 - Per-project runtime isolation
 - Auto `.mcp.json` for Claude Code + auto-config for Claude Desktop, Cursor,
   Gemini CLI, and OpenAI Codex CLI via `npx @mosaicxr-ai/create-bridge`

--- a/README.md
+++ b/README.md
@@ -353,8 +353,13 @@ npm install
 npm run build
 npm test
 
+# Installer CLI
+cd ../create-bridge
+npm install
+npm test
+
 # Unity package — install via file: reference in a test project's manifest.json
-# See TESTING.md (coming soon) for setup details.
+# See TESTING.md for the full test workflow (all three suites).
 ```
 
 Monorepo layout:

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,129 @@
+# Testing Mosaic Bridge
+
+Mosaic Bridge has three test suites, one per package. The two npm packages run
+headless in CI; the Unity package runs in the Unity Editor's Test Runner.
+
+| Package | Location | Runner | Command |
+|---------|----------|--------|---------|
+| MCP server | `packages/mcp-server` | vitest | `npm test` |
+| Installer CLI | `packages/create-bridge` | vitest | `npm test` |
+| Unity package | `packages/com.mosaic.bridge` | Unity Test Runner (EditMode) | see below |
+
+---
+
+## MCP server — `packages/mcp-server`
+
+TypeScript, tested with [vitest](https://vitest.dev). No Unity required — the
+suite uses in-memory MCP transports and a mock bridge client.
+
+```bash
+cd packages/mcp-server
+npm install
+npm run build      # tsc → dist/
+npm test           # vitest run
+```
+
+What's covered:
+
+- **`conformance.test.ts`** — MCP protocol handshake, tools/resources/prompts
+  capabilities, and tool-call error mapping, driven through a real
+  `createMosaicServer` over an in-memory transport (`tests/helpers.ts`).
+- **`discovery.test.ts`** — discovery-file path resolution, the project-hash
+  derivation, and the cross-platform (Windows backslash) canonicalization.
+- **`prompts.test.ts`** — the four workflow prompts (`preflight`,
+  `scene-interview`, `session-handoff`, `shader-guide`) and their handlers.
+- **`doctor.test.ts`** — the `doctor` diagnostic checks and report formatting.
+- **`version.test.ts`** — `--version` reports the real `package.json` version.
+
+Coverage thresholds are enforced by `vitest.config.ts` (statements 60,
+branches 50, functions 60, lines 60), excluding `src/index.ts` (the CLI entry
+point, exercised via the built binary).
+
+```bash
+npm run coverage   # writes coverage/ with an lcov report
+```
+
+Run the connection diagnostics against a live bridge:
+
+```bash
+node dist/index.js doctor --project-path /path/to/UnityProject
+```
+
+## Installer CLI — `packages/create-bridge`
+
+JavaScript, tested with vitest. No Unity required — tests drive the copy
+helpers and the CLI against temporary directories.
+
+```bash
+cd packages/create-bridge
+npm install
+npm test
+```
+
+What's covered:
+
+- **`tarball-contents.test.js`** — `npm pack --dry-run` ships the full plugin
+  (skills, workflows, agents, commands, and the `.claude-plugin` manifest).
+- **`install-workflows.test.js`** — an end-to-end run against a temp Unity-shaped
+  project writes skills into `.claude/skills` + `.agents/skills` and workflows
+  into `.claude/workflows`.
+- **`version.test.js`** — the CLI `--version` matches `package.json`.
+
+## Unity package — `packages/com.mosaic.bridge`
+
+The bridge is an **Editor-only** plugin, so all tests run in **EditMode**. There
+is a single test assembly, `Mosaic.Bridge.Tests`.
+
+To run:
+
+1. Open a Unity project that includes the `com.mosaic.bridge` package.
+2. `Window → General → Test Runner`.
+3. Select the **EditMode** tab.
+4. Run all, run by category, or run individual tests.
+
+Test categories (see `packages/com.mosaic.bridge/Tests/README.md`):
+
+| Folder | Type | Purpose |
+|--------|------|---------|
+| `Unit/` | NUnit `[Test]` | Framework-level unit tests, Unity APIs mocked where possible |
+| `Integration/` | `[UnityTest]` EditMode | Tests requiring real Unity Editor APIs |
+| `Regression/` | `[Test]` + `[Category("Regression")]` | End-to-end fixtures against the live HTTP bridge |
+| `Fixtures/` | JSON | Input/expected-output data for regression tests |
+
+### Regression suite requires a running bridge
+
+`RegressionTestRunner` loads every `*_smoke.json` fixture in
+`Tests/Regression/Fixtures/` and executes it against the live bridge HTTP
+endpoint (HMAC-signed), producing one NUnit test per fixture. It only passes
+when `BridgeBootstrap` is in the **Running** state — start Unity and let the
+bridge come up before filtering the Test Runner to the `Regression` category.
+
+`CategoryCoverageTests` enforces the coverage invariant: **every registered
+tool category must have at least one fixture, and every fixture must reference a
+real registered tool.** Adding a new tool category therefore requires adding a
+matching `*_smoke.json` fixture, or this test fails.
+
+### Conventions
+
+- Test method naming: `MethodUnderTest_Condition_ExpectedResult`
+  (e.g. `Create_NameIsNullOrEmpty_ReturnsFailWithInvalidParam`).
+- Test class naming: `<ClassUnderTest>Tests`.
+- EditMode only — PlayMode tests are not applicable to an Editor plugin.
+- HttpListener tests use `[Test]` (not `[UnityTest]`) with sync HTTP clients on
+  background threads.
+
+Target: every tool method has a happy-path and an error-path unit test;
+bridge infrastructure maintains ≥ 80% line coverage.
+
+---
+
+## Before committing a change
+
+Per `CLAUDE.md`, after any Unity-side story:
+
+1. Unity console is clean — no errors, no warnings.
+2. The full EditMode suite passes (plus the Regression category against a
+   running bridge for tool changes).
+3. BMad code review before commit.
+
+For npm-package changes, `npm test` must pass in the changed package.

--- a/docs/superpowers/plans/2026-07-12-free-bridge-roadmap.md
+++ b/docs/superpowers/plans/2026-07-12-free-bridge-roadmap.md
@@ -1,0 +1,629 @@
+# Free Bridge Roadmap — Master Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship all 17 open-source ("free bridge") roadmap items in `mosaic-bridge` — closing packaging/diagnostics leaks, delivering the promised runtime layer, and completing the four free backlog epics (audio, ML, networking, performance) — without ever adding a Pro tool to this Apache-2.0 repo.
+
+**Architecture:** Three subsystems move in parallel: the **npm layer** (`packages/mcp-server` TypeScript stdio server + `packages/create-bridge` installer CLI), the **Unity package** (`packages/com.mosaic.bridge` C# Editor tools + knowledge base), and **docs**. Work is sequenced in three waves by payoff-vs-effort. Each large epic (Wave 1/2) gets its own detailed sub-plan at kickoff; this master plan carries fully-executable tasks for Wave 0 and spec-level task contracts (files, interfaces, acceptance) for Waves 1–2.
+
+**Tech Stack:** Node ≥18, TypeScript 5.3, `@modelcontextprotocol/sdk` ^1.0, vitest ^4.1 (mcp-server), `@clack/prompts`/commander (create-bridge). Unity Editor C#, NUnit EditMode, the `[MosaicTool]` reflection registry, JSON knowledge base, fixture-driven regression harness.
+
+## Global Constraints
+
+- **Apache-2.0 only.** Everything committed here is public. **Never** implement a Pro tool category (`measure/`, `annotation/`, `analysis/sightline`, `analysis/solar`, `data/heatmap`, `process/flow`, `process/state`, `view/explode`, `sensor/`, `timeseries/`, or anything from epics E33–E44). If a task drifts into one, stop and move it to `mosaic-pro`.
+- **Patent block:** Do **not** ship Position-Based Dynamics fluid solving (E24.6) before **2027-08-14** (NVIDIA patent). Existing SPH/Verlet/spring-mass sims are fine; PBD specifically is blocked.
+- **Tool pattern (Unity):** every tool = 3 files (`{Action}Params.cs` with `[Required]` on mandatory fields, `{Action}Result.cs`, `{Action}Tool.cs` as a `static class` with `[MosaicTool("category/action", …)]`) + a unit test under `Tests/Unit/Tools/{Category}/` + a `*_smoke.json` regression fixture under `Tests/Regression/Fixtures/`. `CategoryCoverageTests` fails CI if any category lacks a fixture.
+- **Workflow after each Unity story:** Unity console clean (no errors/warnings) → full test suite green → BMad code review before commit.
+- **Loopback only, HMAC-signed.** All MCP↔bridge traffic is `127.0.0.1` HTTP with HMAC-SHA256 request signing (nonce + timestamp). Don't weaken this.
+- **Naming:** MCP server names normalize to `[a-z0-9-]` (Gemini rejects underscores). Tool IDs stay `category/action` kebab.
+- **Release hygiene (repo rule):** after shipping any package version, update README + CHANGELOG + any version-referencing docs in the same change.
+- **Commit style:** conventional commits; frequent, one deliverable each; end messages with the Co-Authored-By trailer.
+
+---
+
+## Wave 0 — P0: unlock value already built (ship this month)
+
+These are leaks, not features. The value already exists; users aren't receiving it. Fastest payoff on the board.
+
+### Task 1: Test harness for `create-bridge`
+
+The installer has **zero** tests today (no `test/` dir, no `test` script). Every later installer task is TDD, so this scaffolding comes first and folds into Task 2's first real deliverable.
+
+**Files:**
+- Modify: `packages/create-bridge/package.json` (add `vitest` devDep + `test` script)
+- Create: `packages/create-bridge/vitest.config.js`
+- Create: `packages/create-bridge/test/smoke.test.js` (one trivial passing test proving the harness runs)
+
+**Interfaces:**
+- Produces: a working `npm test` in `packages/create-bridge` that runs vitest over `test/**/*.test.js`.
+
+- [ ] **Step 1: Add vitest devDependency and test script**
+
+In `packages/create-bridge/package.json`, add a `scripts` block (there is none today) and a devDependency:
+
+```json
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.0"
+  },
+```
+
+Place `"scripts"` right after the `"bin"` block and `"devDependencies"` right after `"dependencies"`.
+
+- [ ] **Step 2: Create vitest config**
+
+Create `packages/create-bridge/vitest.config.js`:
+
+```js
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.js'],
+    environment: 'node',
+  },
+});
+```
+
+- [ ] **Step 3: Write a smoke test that proves the harness runs**
+
+Create `packages/create-bridge/test/smoke.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest';
+import pkg from '../package.json' with { type: 'json' };
+
+describe('create-bridge test harness', () => {
+  it('loads package.json and sees the published version', () => {
+    expect(pkg.name).toBe('@mosaicxr-ai/create-bridge');
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+```
+
+- [ ] **Step 4: Install and run**
+
+Run: `cd packages/create-bridge && npm install && npm test`
+Expected: 1 passing test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/create-bridge/package.json packages/create-bridge/package-lock.json packages/create-bridge/vitest.config.js packages/create-bridge/test/smoke.test.js
+git commit -m "test(create-bridge): add vitest harness"
+```
+
+---
+
+### Task 2: Fix version reporting
+
+`create-bridge/src/cli.js:6` hardcodes `1.0.0-beta.4` (package is `beta.7`); `mcp-server/src/index.ts:88` prints `"mosaic-mcp (see package.json for version)"`. Both make every beta bug report carry wrong version info. Fix: read the real version from `package.json` at runtime.
+
+**Files:**
+- Modify: `packages/create-bridge/src/cli.js:1-13`
+- Test: `packages/create-bridge/test/version.test.js` (Create)
+- Modify: `packages/mcp-server/src/index.ts:79-90`
+- Test: `packages/mcp-server/test/version.test.ts` (Create)
+
+**Interfaces:**
+- Produces (create-bridge): `cli.js` exports/uses `VERSION` sourced from `package.json`, so `--version` matches the published number.
+- Produces (mcp-server): `index.ts` exports `function getVersion(): string` reading `package.json`, used by the `--version` branch.
+
+- [ ] **Step 1: Write the failing create-bridge version test**
+
+Create `packages/create-bridge/test/version.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { VERSION } from '../src/cli.js';
+
+const pkg = JSON.parse(
+  readFileSync(path.resolve(fileURLToPath(import.meta.url), '../../package.json'), 'utf8')
+);
+
+describe('create-bridge --version', () => {
+  it('reports the version from package.json, not a hardcoded string', () => {
+    expect(VERSION).toBe(pkg.version);
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cd packages/create-bridge && npm test -- version`
+Expected: FAIL — `VERSION` is `'1.0.0-beta.4'`, pkg.version is `'1.0.0-beta.7'` (or the import isn't exported).
+
+- [ ] **Step 3: Read the real version in cli.js**
+
+Replace the top of `packages/create-bridge/src/cli.js` (currently `const VERSION = '1.0.0-beta.4';`) with:
+
+```js
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const pkgPath = path.resolve(fileURLToPath(import.meta.url), '../../package.json');
+export const VERSION = JSON.parse(readFileSync(pkgPath, 'utf8')).version;
+```
+
+Keep the existing `.version(VERSION, '-v, --version', 'Show version')` line unchanged.
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `cd packages/create-bridge && npm test -- version`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing mcp-server version test**
+
+Create `packages/mcp-server/test/version.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { getVersion } from '../src/index.js';
+
+const pkg = JSON.parse(
+  readFileSync(path.resolve(fileURLToPath(import.meta.url), '../../package.json'), 'utf8')
+);
+
+describe('mosaic-mcp getVersion()', () => {
+  it('returns the package.json version', () => {
+    expect(getVersion()).toBe(pkg.version);
+  });
+});
+```
+
+- [ ] **Step 6: Run it, verify it fails**
+
+Run: `cd packages/mcp-server && npx vitest run version`
+Expected: FAIL — `getVersion` is not exported.
+
+- [ ] **Step 7: Add getVersion() and use it in the --version branch**
+
+In `packages/mcp-server/src/index.ts`, add after the imports:
+
+```ts
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+export function getVersion(): string {
+  const pkgPath = path.resolve(fileURLToPath(import.meta.url), '../../package.json');
+  return JSON.parse(readFileSync(pkgPath, 'utf8')).version;
+}
+```
+
+Then replace the `--version` branch body (lines ~86-90):
+
+```ts
+  if (opts.version) {
+    process.stdout.write(`mosaic-mcp ${getVersion()}\n`);
+    process.exit(0);
+  }
+```
+
+Note: `../../package.json` resolves correctly from both `src/` (dev/test) and `dist/` (published) because both are one level under the package root.
+
+- [ ] **Step 8: Run it, verify it passes**
+
+Run: `cd packages/mcp-server && npx vitest run version`
+Expected: PASS.
+
+- [ ] **Step 9: Also stamp the Server() version**
+
+In `packages/mcp-server/src/server.ts:56`, the `new Server({ name: 'mosaic-bridge', version: '1.0.0' }, …)` version is hardcoded. Pass it through `CreateServerOptions` instead. Add `version: string` to `CreateServerOptions` (line ~41-45), use `version` in the `Server` ctor, and in `index.ts` pass `version: getVersion()` into `createMosaicServer({ … })`. Update `packages/mcp-server/test/*` server-construction tests if any assert the version.
+
+- [ ] **Step 10: Build, test, commit**
+
+Run: `cd packages/mcp-server && npm run build && npm test`
+Expected: build clean, all tests pass.
+
+```bash
+git add packages/create-bridge/src/cli.js packages/create-bridge/test/version.test.js \
+        packages/mcp-server/src/index.ts packages/mcp-server/src/server.ts packages/mcp-server/test/version.test.ts
+git commit -m "fix: report real package version in create-bridge and mcp-server --version"
+```
+
+---
+
+### Task 3: Ship the complete plugin in the npm tarball + install workflows
+
+Two defects: (a) `create-bridge/package.json` `files` ships only `plugin/skills`, `plugin/workflows`, `plugin/config.yaml` — the `agents/`, `commands/`, and `.claude-plugin/` dirs (Zara/Ray/Max agents + slash commands + the Claude Code plugin manifest) are excluded from the tarball entirely; (b) `flow.js` copies only `plugin/skills` into projects — `workflows/` is shipped-but-never-installed. Fix both: complete the tarball, and copy workflows alongside skills so the installed project actually has them.
+
+**Files:**
+- Modify: `packages/create-bridge/package.json:16-24` (`files` array)
+- Modify: `packages/create-bridge/src/flow.js:11,101-115` (add workflows copy)
+- Test: `packages/create-bridge/test/tarball-contents.test.js` (Create)
+- Test: `packages/create-bridge/test/install-workflows.test.js` (Create)
+
+**Interfaces:**
+- Consumes: `copyDirSync(src, dst)` from `./utils.js` (already used for skills).
+- Produces: after `runInteractive`, the project contains `.claude/skills/*`, `.agents/skills/*`, **and** `.claude/workflows/*`. The published tarball includes every `plugin/**` path.
+
+- [ ] **Step 1: Write the failing tarball-contents test**
+
+Create `packages/create-bridge/test/tarball-contents.test.js`. `npm pack --dry-run --json` lists exactly what would ship:
+
+```js
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const pkgDir = path.resolve(fileURLToPath(import.meta.url), '../..');
+
+function packedFiles() {
+  const out = execFileSync('npm', ['pack', '--dry-run', '--json'], { cwd: pkgDir, encoding: 'utf8' });
+  return JSON.parse(out)[0].files.map(f => f.path);
+}
+
+describe('published tarball', () => {
+  const files = packedFiles();
+  it('includes the full plugin: agents, commands, and .claude-plugin manifest', () => {
+    expect(files.some(f => f.startsWith('plugin/agents/'))).toBe(true);
+    expect(files.some(f => f.startsWith('plugin/commands/'))).toBe(true);
+    expect(files.some(f => f === 'plugin/.claude-plugin/plugin.json')).toBe(true);
+  });
+  it('still includes skills and workflows', () => {
+    expect(files.some(f => f.startsWith('plugin/skills/'))).toBe(true);
+    expect(files.some(f => f.startsWith('plugin/workflows/'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cd packages/create-bridge && npm test -- tarball`
+Expected: FAIL — agents/commands/.claude-plugin not in the packed file list.
+
+- [ ] **Step 3: Complete the `files` array**
+
+In `packages/create-bridge/package.json`, replace the plugin entries in `files` with a single recursive include plus the dotfile manifest (npm excludes dot-directories unless named):
+
+```json
+  "files": [
+    "bin/**/*.js",
+    "src/**/*.js",
+    "plugin/**",
+    "plugin/.claude-plugin/**",
+    "README.md",
+    "LICENSE"
+  ],
+```
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `cd packages/create-bridge && npm test -- tarball`
+Expected: PASS (all plugin paths present).
+
+- [ ] **Step 5: Write the failing install-workflows test**
+
+Create `packages/create-bridge/test/install-workflows.test.js`. This drives the real copy helpers against a temp project:
+
+```js
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { copyDirSync } from '../src/utils.js';
+
+const PLUGIN = path.resolve(fileURLToPath(import.meta.url), '../../plugin');
+let tmp;
+afterEach(() => { if (tmp) rmSync(tmp, { recursive: true, force: true }); });
+
+describe('workflow installation', () => {
+  it('copies workflows into the project .claude/workflows', () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'mosaic-'));
+    const dst = path.join(tmp, '.claude', 'workflows');
+    copyDirSync(path.join(PLUGIN, 'workflows'), dst);
+    expect(existsSync(dst)).toBe(true);
+    // preflight/scene-plan/shader-guide/session-handoff each ship a workflow.md
+    const dirs = readdirSync(dst);
+    expect(dirs).toEqual(expect.arrayContaining(['preflight', 'scene-plan', 'shader-guide', 'session-handoff']));
+  });
+});
+```
+
+- [ ] **Step 6: Run it, verify it fails or passes-trivially, then wire flow.js**
+
+Run: `cd packages/create-bridge && npm test -- install-workflows`
+(This tests the helper directly, so it may pass; the real wiring is in `flow.js`.) Now add a `WORKFLOWS_SRC` const and copy call to `flow.js`.
+
+In `packages/create-bridge/src/flow.js`, after line 11:
+
+```js
+const WORKFLOWS_SRC = path.resolve(fileURLToPath(import.meta.url), '../../plugin/workflows');
+```
+
+In the skills-install `try` block (lines 105-115), after the two `copyDirSync` skills calls, add:
+
+```js
+    const workflowsDst = path.join(projectInfo.projectPath, '.claude', 'workflows');
+    copyDirSync(WORKFLOWS_SRC, workflowsDst);
+```
+
+and update the success message to `'✓ Mosaic Bridge skills + workflows installed (.claude + .agents)'`.
+
+- [ ] **Step 7: Full installer smoke via --skip-unity --skip-clients on a fake project**
+
+Add to `install-workflows.test.js` a test that runs the CLI end-to-end against a temp Unity-looking dir (create `Assets/` + `ProjectSettings/ProjectVersion.txt`), invoking `bin/create-bridge.js --project-path <tmp> --yes --skip-unity --skip-clients --skip-claude`, then asserts `.claude/workflows/preflight` exists. Use `execFileSync(process.execPath, [binPath, …])`.
+
+- [ ] **Step 8: Run the suite**
+
+Run: `cd packages/create-bridge && npm test`
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/create-bridge/package.json packages/create-bridge/src/flow.js packages/create-bridge/test/tarball-contents.test.js packages/create-bridge/test/install-workflows.test.js
+git commit -m "fix(create-bridge): ship full plugin in tarball and install workflows into project"
+```
+
+---
+
+### Task 4: MCP prompts capability
+
+The server declares only `tools` and `resources`. The scene-building interview, session-start preflight, shader guide, and session handoff are workflow rules that today reach users **only** if the installer wrote a client instruction file — every other client silently misses them. Exposing them as native MCP prompts (`prompts/list` + `prompts/get`) delivers them over the protocol to any client.
+
+**Files:**
+- Modify: `packages/mcp-server/src/server.ts:55-63` (add `prompts: {}` capability), and register `ListPromptsRequestSchema` + `GetPromptRequestSchema` handlers
+- Create: `packages/mcp-server/src/prompts.ts` (the four prompt definitions)
+- Test: `packages/mcp-server/test/prompts.test.ts` (Create)
+
+**Interfaces:**
+- Produces: `export const MOSAIC_PROMPTS: McpPromptDef[]` where `McpPromptDef = { name: string; description: string; arguments?: {name,description,required}[]; build(args): string }`. Prompt names: `scene-interview`, `preflight`, `shader-guide`, `session-handoff`.
+- Consumes: prompt *content* is derived from the same source text as `templates.js` — extract the shared blocks so installer instruction files and MCP prompts don't drift. (Create `packages/create-bridge/src/protocol-blocks.js`? No — keep MCP self-contained: copy the canonical block text into `prompts.ts` and add a CI check `check-stale-docs`-style that diffs the two. Simpler: `prompts.ts` owns the text; a follow-up unifies.)
+
+- [ ] **Step 1: Write the failing prompts test**
+
+Create `packages/mcp-server/test/prompts.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { MOSAIC_PROMPTS } from '../src/prompts.js';
+
+describe('MCP prompts', () => {
+  it('exposes the four workflow prompts', () => {
+    const names = MOSAIC_PROMPTS.map(p => p.name).sort();
+    expect(names).toEqual(['preflight', 'scene-interview', 'session-handoff', 'shader-guide']);
+  });
+  it('scene-interview builds non-empty guidance text', () => {
+    const p = MOSAIC_PROMPTS.find(p => p.name === 'scene-interview')!;
+    const text = p.build({});
+    expect(text).toMatch(/interview/i);
+    expect(text.length).toBeGreaterThan(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run: `cd packages/mcp-server && npx vitest run prompts`
+Expected: FAIL — `../src/prompts.js` does not exist.
+
+- [ ] **Step 3: Create prompts.ts**
+
+Create `packages/mcp-server/src/prompts.ts` with the four definitions. Content is the canonical protocol text (Scene-Building Interview Protocol, Session Start / preflight, ShaderGraph Serialization Rules, Session Handoff) lifted from `create-bridge/src/templates.js`'s `BASE_INSTRUCTIONS`. Shape:
+
+```ts
+export interface McpPromptDef {
+  name: string;
+  description: string;
+  arguments?: { name: string; description: string; required: boolean }[];
+  build(args: Record<string, string>): string;
+}
+
+const SCENE_INTERVIEW = `On any vague "build a scene" request, STOP. Call no tools yet. Ask these Tier-1 questions:
+1. Scene type (interior/exterior/stylized/realistic)?
+2. Geographic or art reference?
+3. Scale (room / building / district / open world)?
+4. Player perspective (first-person / top-down / orbit)?
+Then produce a ScenePlan summary and WAIT for confirmation before building.
+Spatial coherence: every placed object's Y = terrain/sample-height(x,z) + offset; never Y=0 outdoors.`;
+
+// … PREFLIGHT, SHADER_GUIDE, SESSION_HANDOFF blocks …
+
+export const MOSAIC_PROMPTS: McpPromptDef[] = [
+  { name: 'scene-interview', description: 'Interview protocol before building any scene', build: () => SCENE_INTERVIEW },
+  { name: 'preflight', description: 'Run project/preflight and interpret pipeline/packages/errors at session start', build: () => PREFLIGHT },
+  { name: 'shader-guide', description: 'ShaderGraph serialization + node-wiring rules (Unity 14.x+)', build: () => SHADER_GUIDE },
+  { name: 'session-handoff', description: 'Write docs/Sessions/{user}/SESSION_NOTES.md before ending', build: () => SESSION_HANDOFF },
+];
+```
+
+Copy the full block text verbatim from `templates.js` — do not paraphrase (keeps prompts and installer files in lockstep).
+
+- [ ] **Step 4: Run it, verify it passes**
+
+Run: `cd packages/mcp-server && npx vitest run prompts`
+Expected: PASS.
+
+- [ ] **Step 5: Register the handlers in server.ts**
+
+Import `ListPromptsRequestSchema`, `GetPromptRequestSchema` from the SDK types. Add `prompts: {}` to the `capabilities` object (line ~58-62). After the resources handlers, register:
+
+```ts
+  server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+    prompts: MOSAIC_PROMPTS.map(p => ({
+      name: p.name,
+      description: p.description,
+      arguments: p.arguments ?? [],
+    })),
+  }));
+
+  server.setRequestHandler(GetPromptRequestSchema, async (req) => {
+    const def = MOSAIC_PROMPTS.find(p => p.name === req.params.name);
+    if (!def) throw new McpError(ErrorCode.InvalidRequest, `Unknown prompt: ${req.params.name}`);
+    return {
+      messages: [{
+        role: 'user' as const,
+        content: { type: 'text' as const, text: def.build(req.params.arguments ?? {}) },
+      }],
+    };
+  });
+```
+
+- [ ] **Step 6: Add an integration test through the real Server**
+
+Extend `prompts.test.ts` to build a server via `createMosaicServer(...)` with a mock client and assert `prompts/list` returns 4 and `prompts/get {name:'preflight'}` returns a text message. Follow the in-memory-transport pattern already used in the mcp-server test suite (mirror `server.test.ts` setup).
+
+- [ ] **Step 7: Build, test, commit**
+
+Run: `cd packages/mcp-server && npm run build && npm test`
+Expected: clean.
+
+```bash
+git add packages/mcp-server/src/prompts.ts packages/mcp-server/src/server.ts packages/mcp-server/test/prompts.test.ts
+git commit -m "feat(mcp-server): expose scene/preflight/shader/handoff workflow prompts via MCP prompts capability"
+```
+
+---
+
+### Task 5: `bridge doctor` diagnostic command
+
+Connection failures surface as an opaque "Connection closed" (the Windows path-hash bug proved how costly that is). A `doctor` subcommand that checks the discovery file, live editor PIDs, port reachability, HMAC handshake, and clock skew turns hour-long support threads into a copy-pasteable report.
+
+**Files:**
+- Create: `packages/mcp-server/src/doctor.ts` (checks + report formatter)
+- Modify: `packages/mcp-server/src/index.ts:15-44,79-90` (parse `doctor` / `--doctor`, dispatch)
+- Test: `packages/mcp-server/test/doctor.test.ts` (Create)
+
+**Interfaces:**
+- Consumes: `readDiscovery(opts)` (`discovery.ts`), `BridgeClient` (`bridge-client.ts`) `.health()`, the instance-registry reader used by discovery.
+- Produces: `export async function runDoctor(opts: DiscoveryOptions): Promise<DoctorReport>` where `DoctorReport = { checks: {name, status: 'pass'|'warn'|'fail', detail: string}[]; ok: boolean }`, and `export function formatDoctorReport(r: DoctorReport): string`.
+
+- [ ] **Step 1: Write failing tests for the check runner**
+
+Create `packages/mcp-server/test/doctor.test.ts` — assert `runDoctor` with a bogus `runtimeDir` yields a `fail` on the "discovery file" check and `ok === false`; assert `formatDoctorReport` renders one line per check with a `✓/⚠/✗` glyph. Inject a fake discovery dir via `opts.runtimeDir` pointing at a temp folder.
+
+- [ ] **Step 2: Run, verify fail** — `npx vitest run doctor` → FAIL (module missing).
+
+- [ ] **Step 3: Implement `doctor.ts`** with checks, in order:
+  1. **Discovery file** — exists + parses + HMAC signature valid (reuse discovery integrity check; `warn` if unsigned, `fail` if missing/corrupt).
+  2. **Live editor** — instance-registry lists a live PID for this project (`fail` if zero, `warn` if multiple with guidance to pass `--project-path`).
+  3. **Port reachable** — TCP connect to `127.0.0.1:<port>` (`fail` on ECONNREFUSED).
+  4. **Health + HMAC** — `client.health()` returns `status:'ok'` with a valid signature (`fail` on 401 → "secret rotated, restart client").
+  5. **Clock skew** — compare local time to the discovery file mtime / a health-response timestamp; `warn` if >30s (HMAC nonce windows fail on skew).
+  Each check is try/caught into a `{name,status,detail}` record; never throw out of `runDoctor`.
+
+- [ ] **Step 4: Run, verify pass** — `npx vitest run doctor` → PASS.
+
+- [ ] **Step 5: Wire the subcommand** — in `index.ts`, treat `argv[0] === 'doctor'` (or `--doctor`) as a mode: run `runDoctor`, `process.stdout.write(formatDoctorReport(r))`, exit `r.ok ? 0 : 1`. Add `doctor` to `printUsage()`.
+
+- [ ] **Step 6: Manual smoke** — with a bridge NOT running: `node dist/index.js doctor --project-path <path>` prints a readable report ending in a fail. Document expected output in the test as a snapshot.
+
+- [ ] **Step 7: Build, test, commit**
+
+```bash
+git add packages/mcp-server/src/doctor.ts packages/mcp-server/src/index.ts packages/mcp-server/test/doctor.test.ts
+git commit -m "feat(mcp-server): add 'doctor' command for connection diagnostics"
+```
+
+---
+
+### Wave 0 wrap-up
+
+- [ ] Update `packages/mcp-server/CHANGELOG.md` and `packages/create-bridge/CHANGELOG.md` with the four fixes; bump both to the next `-beta` (mcp-server → beta.7, create-bridge → beta.8). Update the root `README.md` "What's inside" if it enumerates version numbers or the `doctor`/prompts capabilities.
+- [ ] Run both package test suites green.
+- [ ] BMad code review, then a release commit.
+
+---
+
+## Wave 1 — P1: the promised runtime layer (this quarter)
+
+Each item below is spec-level. **At kickoff, each gets its own detailed TDD sub-plan** via the writing-plans skill (they're multi-day-to-multi-week and writing full speculative code now would be a plan failure). Sequence within the wave: 1.4 (play-mode) and 1.1 (KB tools) first — they de-risk everything else — then 1.2 (execute-plan) which depends on both, then 1.3/1.6 (new tool categories) in parallel, docs (1.5) continuous.
+
+### Task 1.1: Runtime KB tools — `kb/query`, `kb/fetch`, `kb/watch`
+
+**Subsystem:** Unity package (new `Editor/Tools/Kb/` category) + MCP server passthrough.
+**Files (Unity):** `Editor/Tools/Kb/{Query,Fetch,Watch}{Params,Result,Tool}.cs` + `Tests/Unit/Tools/Kb/KbToolTests.cs` + 3 regression fixtures. Reuse `Editor/Core/KnowledgeProvider/KnowledgeBase.cs`.
+**Files (MCP):** none new — these register through the dynamic registry automatically; add a passthrough integration test.
+**Acceptance:** `kb/query {q:"URP color property"}` returns ranked KB entries with snippets; `kb/fetch {category,key}` returns full entry JSON; `kb/watch {sessionId}` returns entries whose `sceneState` drifted from a recorded ScenePlan. All three appear in `tools/list` over MCP. Answers the fluid-session pain (3–4 iterations on `_Color` vs `_BaseColor`).
+**Effort:** ~weeks. **Roadmap:** named v1.0-stable item.
+
+### Task 1.2: `scene/execute-plan`
+
+**Subsystem:** Unity package (`Editor/Tools/Scene/`).
+**Files:** `ExecutePlanParams.cs` (takes a validated ScenePlan JSON), `ExecutePlanResult.cs`, `ExecutePlanTool.cs` + unit test + fixture. Drives the existing 8-phase pipeline (terrain → water → textures → sky/lighting → structures → vegetation → post → camera) and enforces the spatial-coherence contract via `terrain/sample-height`.
+**Interfaces:** consumes the ScenePlan schema from KB entry `scene/scene-composition-guide`; calls existing tools (`terrain/*`, `gameobject/*`, `material/*`) through the in-process dispatcher.
+**Acceptance:** given a ScenePlan, one call builds the scene in deterministic phase order with all Y-positions resolved to terrain height; returns per-phase results + screenshots. Marked "optional/not built" in the current spec — this ships it.
+**Effort:** ~weeks. **Depends on:** 1.1 (KB-driven validation), 1.4 (play-mode for sims).
+
+### Task 1.3: Performance & scale tools — `optimize/*` (epic E42)
+
+**Subsystem:** Unity package (new `Editor/Tools/Optimize/`).
+**Tools:** `optimize/mesh-combine`, `optimize/gpu-instancing`, `optimize/batching`, `optimize/occlusion-setup`, `optimize/suggest` (reads the existing `profiler/*` tools and recommends fixes). Each = 3 files + unit test + fixture.
+**Acceptance:** `optimize/suggest` returns actionable items keyed off profiler stats; `optimize/mesh-combine` reduces draw calls on a test scene (assert combined mesh count). Broadest-audience free epic.
+**Effort:** ~weeks.
+
+### Task 1.4: Play-mode awareness on tools
+
+**Subsystem:** Unity package (Contracts + pipeline).
+**Files:** add `RequiresPlayMode` to `MosaicToolAttribute` (`Editor/Contracts/Attributes/`); a pipeline stage warning (`Editor/Core/Pipeline/Stages/`) that flags/optionally auto-enters play mode; tag the sim tools (fluid, smoke, cloth, etc.). Tests under `Tests/Unit/`.
+**Acceptance:** calling a `RequiresPlayMode` tool in edit mode returns a pipeline warning ("enter Play mode to see results") instead of silent nothing; opens the door to PlayMode test coverage. Fixes the fluid-session "nothing shows" dead-end.
+**Effort:** ~days. **Do first in wave** (de-risks 1.2/1.3).
+
+### Task 1.5: Bridge docs site + `TESTING.md`
+
+**Subsystem:** docs (`mosaic-docs` + repo root).
+**Files:** `TESTING.md` at repo root (README links it, it doesn't exist); real bridge content in `mosaic-docs/docs` (currently 100% BMAD, zero bridge). Tool reference generated from the registry, quickstart, the Scene Intelligence guide.
+**Acceptance:** README's `TESTING.md` link resolves; docs site has a bridge quickstart + tool reference. Both are v1.0-stable / Asset Store prerequisites.
+**Effort:** ~weeks (continuous through the wave).
+
+### Task 1.6: Audio & signal tools — `audio/*` (epic E27)
+
+**Subsystem:** Unity package (extend `Editor/Tools/Audio/` — thinnest category, 3 tools today).
+**Tools:** `audio/procedural-sfx` (synthesized clips), `audio/mixer-create` + `audio/mixer-route`, `audio/spatial-profile` (occlusion/reverb zones). Each = 3 files + test + fixture. Ship the planned `audio-attenuation` KB entry alongside.
+**Acceptance:** new tools appear in `tools/list`; procedural SFX generates a playable AudioClip asset; KB entry present. Knowledge + tools land together.
+**Effort:** ~weeks.
+
+---
+
+## Wave 2 — P2: bigger bets & polish (next horizon)
+
+Spec-level; each gets a sub-plan at kickoff. Ordered by leverage.
+
+### Task 2.1: Terrain at scale + tree-import fix
+**Unity.** Tiling guidance/tools for large scenes (resolution insufficient today) + fix trees whose nested-child `MeshRenderer`s are ignored by Unity's terrain system (flatten renderers on import). Both documented in gap analysis. Add `terrain/tile`-style tool + a fix in the tree-placement path + regression fixtures. **Effort:** ~weeks.
+
+### Task 2.2: KB expansion pack
+**Unity KB.** Add the README-named missing domains: animation timing, spatial metrics, color temperature, lighting presets. JSON entries + `.meta`, wire into `INDEX`, keep 100% tool coverage. Compounds with `kb/query` (1.1). **Effort:** ~days.
+
+### Task 2.3: Deprecated-API migration tool
+**Unity.** `script/migrate-api` (or `reflection/`-backed) scans project scripts for obsolete Unity APIs and auto-fixes, built on existing `script/*` + `reflection/*`. v1.1 roadmap item. 3 files + test + fixture. **Effort:** ~weeks.
+
+### Task 2.4: Procgen visual regression goldens
+**Unity tests.** No real session has ever exercised the 17 procgen tools — least-validated flagship. Add screenshot-based golden fixtures through the existing regression harness (`Tests/Regression/`) for each procgen algo. **Effort:** ~weeks.
+
+### Task 2.5: Networking & multiplayer — `network/*` (epic E32)
+**Unity.** Netcode-for-GameObjects scaffolding, `NetworkObject` setup, sync validation. Big surface + heavy test burden — schedule **after** E42 (1.3). Full sub-plan required. **Effort:** ~quarter.
+
+### Task 2.6: In-engine ML — `ml/*` (epic E29)
+**Unity.** Unity Sentis model import + inference tools. Differentiating (no competing bridge has it) but niche today — a v1.2 headline. Full sub-plan required. **Effort:** ~quarter.
+
+### Task 2.7: HTTP transport + TLS for the MCP server
+**MCP server.** Streamable-HTTP transport for remote/containerized clients; the discovery contract already reserves `tls_enabled`. **Defer** until a real remote-client request exists — stdio covers every currently supported client. **Effort:** ~quarter.
+
+---
+
+## Blocked — do not build here
+- **PBD fluids (E24.6):** patent-blocked until **2027-08-14**.
+- **All Pro categories (E33–E44 + measure/annotation/analysis/sensor/timeseries/etc.):** belong in the private `mosaic-pro` repo. Committing here makes them Apache-2.0, unrecoverably.
+
+---
+
+## Self-Review
+
+**Spec coverage:** all 17 roadmap items mapped — Wave 0: version fix (Task 2), plugin/tarball (Task 3), MCP prompts (Task 4), doctor (Task 5); Wave 1: KB tools (1.1), execute-plan (1.2), optimize (1.3), play-mode (1.4), docs (1.5), audio (1.6); Wave 2: terrain (2.1), KB expansion (2.2), API migration (2.3), procgen goldens (2.4), network (2.5), ml (2.6), HTTP/TLS (2.7). Task 1 (test harness) is enabling scaffolding folded into Wave 0. ✅
+**Placeholder scan:** Wave 0 tasks carry real code and exact commands. Waves 1–2 are intentionally spec-level with explicit "own sub-plan at kickoff" — not placeholders but scoped deferrals, since writing speculative multi-week C# now would be the plan failure the skill warns against. ✅
+**Type consistency:** `getVersion()`, `VERSION`, `copyDirSync`, `MOSAIC_PROMPTS`/`McpPromptDef`, `runDoctor`/`DoctorReport`/`formatDoctorReport` are named identically wherever referenced. ✅

--- a/docs/superpowers/plans/2026-07-12-free-bridge-roadmap.md
+++ b/docs/superpowers/plans/2026-07-12-free-bridge-roadmap.md
@@ -622,6 +622,24 @@ Spec-level; each gets a sub-plan at kickoff. Ordered by leverage.
 
 ---
 
+## Findings from live-bridge testing (2026-07-12)
+
+Discovered while building the procgen demo scene against a live Unity 6000.3 bridge. Both are real
+product defects worth their own fixes:
+
+- **`editor/run-block` fixed ~22s job timeout is too short.** On any project where compile +
+  domain-reload exceeds ~22s, the submitted block compiles (reaches `pending`) but its post-reload
+  execution never completes inside the server-side job budget, so it always returns `timed out`. There
+  is no way to extend it. This makes scripted editor automation (e.g. creating a post-processing
+  volume, bulk asset ops) unusable on non-trivial projects. **Fix:** make the timeout configurable /
+  much larger, or poll indefinitely with a heartbeat rather than a hard job deadline. *(P1-class.)*
+- **Atmospheric skybox shaders clip without tonemapping.** `rendering/atmosphere-create` emits HDR sky
+  values that clip to mustard (Preetham) or white (Bruneton) unless a URP tonemapping volume is present
+  — and there is no tool to create a post-processing/tonemapping volume, so an AI agent cannot produce a
+  good-looking atmospheric sky unaided. **Fix:** add a `graphics/post-process-create` (or
+  `rendering/tonemapping`) tool that builds a global Volume + VolumeProfile with ACES tonemapping and
+  enables `renderPostProcessing` on the target camera. *(P2-class; also unblocks polished demo imagery.)*
+
 ## Self-Review
 
 **Spec coverage:** all 17 roadmap items mapped — Wave 0: version fix (Task 2), plugin/tarball (Task 3), MCP prompts (Task 4), doctor (Task 5); Wave 1: KB tools (1.1), execute-plan (1.2), optimize (1.3), play-mode (1.4), docs (1.5), audio (1.6); Wave 2: terrain (2.1), KB expansion (2.2), API migration (2.3), procgen goldens (2.4), network (2.5), ml (2.6), HTTP/TLS (2.7). Task 1 (test harness) is enabling scaffolding folded into Wave 0. ✅

--- a/docs/superpowers/plans/2026-07-12-free-bridge-roadmap.md
+++ b/docs/superpowers/plans/2026-07-12-free-bridge-roadmap.md
@@ -640,6 +640,35 @@ product defects worth their own fixes:
   `rendering/tonemapping`) tool that builds a global Volume + VolumeProfile with ACES tonemapping and
   enables `renderPostProcessing` on the target camera. *(P2-class; also unblocks polished demo imagery.)*
 
+## Next session (turnkey): `graphics/post-process-create` tool
+
+Motivated by the tonemapping finding above; also finishes the procgen demo image.
+
+**Enabler (do first):** temporarily point the demo Unity project at the local package so new tools load
+and can be verified live. In `/Users/mousasoutari/Projects/Unity/TestMosaic-2/Packages/manifest.json`,
+change `com.mosaic.bridge` from the git URL to
+`"file:/Users/mousasoutari/Projects/mosaic-bridge/packages/com.mosaic.bridge"`, let Unity re-resolve,
+then run `doctor`. Revert to the git URL when done.
+
+**Files (follow the 3-file pattern of `GraphicsSetPostProcessing*`):**
+- Create `Editor/Tools/Graphics/GraphicsPostProcessCreateParams.cs` — `[Required]`-free params:
+  `tonemappingMode` (None|Neutral|ACES, default ACES), `bloomIntensity` (default 0.5),
+  `bloomThreshold` (0.9), `postExposure` (0), `contrast` (0), `saturation` (0),
+  `volumeName` (default "Global Volume"), `cameraName` (optional — enable post on this camera),
+  `profileSavePath` (default "Assets/PostFX.asset").
+- Create `Editor/Tools/Graphics/GraphicsPostProcessCreateResult.cs` — `ProfilePath`, `VolumeInstanceId`,
+  `CameraPostEnabled` (bool).
+- Create `Editor/Tools/Graphics/GraphicsPostProcessCreateTool.cs` — `[MosaicTool("graphics/post-process-create", …)]`
+  static class. Build a `VolumeProfile`, `profile.Add<Tonemapping>()` / `Bloom` / `ColorAdjustments`
+  with overrideState=true, `AssetDatabase.CreateAsset`, create/find the global `Volume` GameObject,
+  assign `sharedProfile`, and if `cameraName` set, `cam.GetUniversalAdditionalCameraData().renderPostProcessing = true`.
+  Guard URP-only (return a clear error if the pipeline isn't URP/HDRP — read from `project/preflight` logic).
+- Test `Tests/Unit/Tools/Graphics/GraphicsToolTests.cs` — add happy-path + non-URP error-path cases.
+- Fixture `Tests/Regression/Fixtures/graphics_post_process_create_smoke.json`.
+
+**Verify:** Unity console clean → EditMode tests green → run it via the bridge on the saved demo scene,
+re-screenshot → confirm the sky no longer clips. Then finish the README gallery.
+
 ## Self-Review
 
 **Spec coverage:** all 17 roadmap items mapped — Wave 0: version fix (Task 2), plugin/tarball (Task 3), MCP prompts (Task 4), doctor (Task 5); Wave 1: KB tools (1.1), execute-plan (1.2), optimize (1.3), play-mode (1.4), docs (1.5), audio (1.6); Wave 2: terrain (2.1), KB expansion (2.2), API migration (2.3), procgen goldens (2.4), network (2.5), ml (2.6), HTTP/TLS (2.7). Task 1 (test harness) is enabling scaffolding folded into Wave 0. ✅

--- a/packages/com.mosaic.bridge/CHANGELOG.md
+++ b/packages/com.mosaic.bridge/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **MCP server auto-spawn used the wrong package name.** `McpServerProcess` and
+  `McpServerPanel` referenced `@mosaic/mcp-server` (which is not the published
+  package) for the local-install lookup, the npx spawn arguments, and the
+  user-facing log/UI text. Corrected to `@mosaicxr-ai/mcp-server` so auto-spawn
+  and local-install detection actually resolve. (`ClaudeCodeConfigurator` already
+  checked the correct name first, with `@mosaic` retained only as a legacy fallback.)
+
 ## [1.0.0-beta.5] — 2026-05-05
 
 ### Added

--- a/packages/com.mosaic.bridge/Editor/Core/Mcp/McpServerProcess.cs
+++ b/packages/com.mosaic.bridge/Editor/Core/Mcp/McpServerProcess.cs
@@ -91,12 +91,12 @@ namespace Mosaic.Bridge.Core.Mcp
                 }
                 else if (System.IO.File.Exists(System.IO.Path.Combine(
                     System.IO.Path.GetDirectoryName(UnityEngine.Application.dataPath) ?? "",
-                    "node_modules", "@mosaic", "mcp-server", "dist", "index.js")))
+                    "node_modules", "@mosaicxr-ai", "mcp-server", "dist", "index.js")))
                 {
                     // Local npm install found
                     var localPath = System.IO.Path.Combine(
                         System.IO.Path.GetDirectoryName(UnityEngine.Application.dataPath),
-                        "node_modules", "@mosaic", "mcp-server", "dist", "index.js");
+                        "node_modules", "@mosaicxr-ai", "mcp-server", "dist", "index.js");
                     psi.FileName = "node";
                     psi.Arguments = $"\"{localPath}\" --discovery \"{discoveryFilePath}\"";
                     _logger.Info("MCP server using local install", ("path", (object)localPath));
@@ -104,7 +104,7 @@ namespace Mosaic.Bridge.Core.Mcp
                 else if (_launcher is SystemProcessLauncher)
                 {
                     // Production path: npm package not available — skip spawn silently
-                    _logger.Debug("MCP server not spawned: @mosaic/mcp-server not installed. " +
+                    _logger.Debug("MCP server not spawned: @mosaicxr-ai/mcp-server not installed. " +
                         "Set Mosaic.Bridge.McpServerPath in EditorPrefs or install the npm package.");
                     return 0;
                 }
@@ -112,7 +112,7 @@ namespace Mosaic.Bridge.Core.Mcp
                 {
                     // Test/custom launcher path: use npx as fallback
                     psi.FileName = "npx";
-                    psi.Arguments = $"@mosaic/mcp-server --discovery \"{discoveryFilePath}\"";
+                    psi.Arguments = $"@mosaicxr-ai/mcp-server --discovery \"{discoveryFilePath}\"";
                 }
 
                 psi.UseShellExecute = false;

--- a/packages/com.mosaic.bridge/Editor/UI/McpServerPanel.cs
+++ b/packages/com.mosaic.bridge/Editor/UI/McpServerPanel.cs
@@ -49,7 +49,7 @@ namespace Mosaic.Bridge.UI
                 if (string.IsNullOrEmpty(customPath))
                 {
                     EditorGUILayout.HelpBox(
-                        "No custom path set. MCP server will spawn via npx when @mosaic/mcp-server is installed.",
+                        "No custom path set. MCP server will spawn via npx when @mosaicxr-ai/mcp-server is installed.",
                         MessageType.Info);
                 }
 

--- a/packages/com.mosaic.bridge/Tests/Mcp/McpServerProcessIntegrationTests.cs
+++ b/packages/com.mosaic.bridge/Tests/Mcp/McpServerProcessIntegrationTests.cs
@@ -10,9 +10,9 @@ namespace Mosaic.Bridge.Tests.Mcp
         public void SpawnAndShutdown_NodeProcess()
         {
             // Integration test placeholder:
-            // Requires Node.js installed and @mosaic/mcp-server package available.
+            // Requires Node.js installed and @mosaicxr-ai/mcp-server package available.
             // Will be implemented when the MCP server package is published.
-            Assert.Ignore("Integration test -- requires Node.js and @mosaic/mcp-server");
+            Assert.Ignore("Integration test -- requires Node.js and @mosaicxr-ai/mcp-server");
         }
     }
 }

--- a/packages/com.mosaic.bridge/Tests/Mcp/McpServerProcessTests.cs
+++ b/packages/com.mosaic.bridge/Tests/Mcp/McpServerProcessTests.cs
@@ -42,7 +42,8 @@ namespace Mosaic.Bridge.Tests.Mcp
 
             var psi = _launcher.StartCalls[0];
             Assert.AreEqual("npx", psi.FileName);
-            Assert.That(psi.Arguments, Does.Contain("@mosaic/mcp-server"));
+            Assert.That(psi.Arguments, Does.Contain("@mosaicxr-ai/mcp-server"));
+            Assert.That(psi.Arguments, Does.Not.Contain("@mosaic/mcp-server"));
             Assert.That(psi.Arguments, Does.Contain("--discovery"));
             Assert.That(psi.Arguments, Does.Contain("/tmp/discovery.json"));
             Assert.IsFalse(psi.UseShellExecute);

--- a/packages/create-bridge/CHANGELOG.md
+++ b/packages/create-bridge/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this package will be documented in this file.
 
+## [1.0.0-beta.8] — 2026-07-12
+
+### Fixed
+
+- **Incomplete published tarball** — the `files` allowlist excluded `plugin/agents`,
+  `plugin/commands`, and the `.claude-plugin/plugin.json` manifest, so the Zara/Ray/Max
+  specialist agents and slash commands never shipped to users. The full `plugin/**` tree
+  is now published.
+- **Workflows never installed** — `plugin/workflows` shipped in the package but the
+  installer only copied `plugin/skills`. Setup now also copies workflows (preflight,
+  scene-plan, shader-guide, session-handoff) into the project's `.claude/workflows`.
+- **`--version` reported the wrong number** — the CLI hardcoded `1.0.0-beta.4`; it now
+  reads the real version from `package.json` at runtime.
+
+### Added
+
+- **Test harness** — `vitest` suite for the installer (tarball contents, version, and an
+  end-to-end skills+workflows install run).
+
+---
+
 ## [1.0.0-beta.7] — 2026-05-05
 
 ### Changed

--- a/packages/create-bridge/package-lock.json
+++ b/packages/create-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mosaicxr-ai/create-bridge",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mosaicxr-ai/create-bridge",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0-beta.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.10.0",

--- a/packages/create-bridge/package-lock.json
+++ b/packages/create-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mosaicxr-ai/create-bridge",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mosaicxr-ai/create-bridge",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.10.0",
@@ -17,6 +17,9 @@
       "bin": {
         "create-bridge": "bin/create-bridge.js",
         "mosaic-bridge-setup": "bin/create-bridge.js"
+      },
+      "devDependencies": {
+        "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -43,6 +46,516 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -52,10 +565,481 @@
         "node": ">=20"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
@@ -74,6 +1058,267 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/packages/create-bridge/package.json
+++ b/packages/create-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mosaicxr-ai/create-bridge",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "Interactive installer for Mosaic Bridge — sets up the Unity package and configures MCP for Claude Code, Claude Desktop, Cursor, and Gemini CLI.",
   "license": "Apache-2.0",
   "author": {

--- a/packages/create-bridge/package.json
+++ b/packages/create-bridge/package.json
@@ -13,6 +13,10 @@
     "create-bridge": "./bin/create-bridge.js",
     "mosaic-bridge-setup": "./bin/create-bridge.js"
   },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "files": [
     "bin/**/*.js",
     "src/**/*.js",
@@ -53,5 +57,8 @@
     "commander": "^14.0.0",
     "picocolors": "^1.1.0",
     "smol-toml": "^1.6.1"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.0"
   }
 }

--- a/packages/create-bridge/package.json
+++ b/packages/create-bridge/package.json
@@ -20,9 +20,8 @@
   "files": [
     "bin/**/*.js",
     "src/**/*.js",
-    "plugin/skills/**",
-    "plugin/workflows/**",
-    "plugin/config.yaml",
+    "plugin/**",
+    "plugin/.claude-plugin/**",
     "README.md",
     "LICENSE"
   ],

--- a/packages/create-bridge/src/cli.js
+++ b/packages/create-bridge/src/cli.js
@@ -1,9 +1,13 @@
 import { Command } from 'commander';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { runInteractive } from './flow.js';
 
-const VERSION = '1.0.0-beta.4';
+const pkgPath = path.resolve(fileURLToPath(import.meta.url), '../../package.json');
+export const VERSION = JSON.parse(readFileSync(pkgPath, 'utf8')).version;
 
 export async function run(argv) {
   const program = new Command()

--- a/packages/create-bridge/src/flow.js
+++ b/packages/create-bridge/src/flow.js
@@ -9,6 +9,7 @@ import { CLAUDE_MD_CONTENT } from './templates.js';
 import { copyDirSync } from './utils.js';
 
 const SKILLS_SRC = path.resolve(fileURLToPath(import.meta.url), '../../plugin/skills');
+const WORKFLOWS_SRC = path.resolve(fileURLToPath(import.meta.url), '../../plugin/workflows');
 
 const BRIDGE_PACKAGE_NAME = 'com.mosaic.bridge';
 const BRIDGE_GIT_URL =
@@ -107,7 +108,12 @@ export async function runInteractive(opts) {
     const agentsSkillsDst = path.join(projectInfo.projectPath, '.agents', 'skills');
     copyDirSync(SKILLS_SRC, claudeSkillsDst);
     copyDirSync(SKILLS_SRC, agentsSkillsDst);
-    p.log.success(pc.green('✓ Mosaic Bridge skills installed (.claude/skills + .agents/skills)'));
+    // Workflows (preflight, scene-plan, shader-guide, session-handoff) ship in the
+    // package but were never installed — copy them alongside the skills so
+    // Claude Code can run them from the project.
+    const workflowsDst = path.join(projectInfo.projectPath, '.claude', 'workflows');
+    copyDirSync(WORKFLOWS_SRC, workflowsDst);
+    p.log.success(pc.green('✓ Mosaic Bridge skills + workflows installed (.claude + .agents/skills)'));
     results.push({ kind: 'skills', ok: true });
   } catch (err) {
     p.log.warn(pc.yellow(`⚠ Skills install skipped: ${err.message}`));

--- a/packages/create-bridge/src/templates.js
+++ b/packages/create-bridge/src/templates.js
@@ -201,6 +201,24 @@ At the end of every session (or when context is running low), write a handoff:
 - Include: pipeline, color property, assets created, errors encountered, remaining work
 - Recovery prompt: "Load session notes from docs/Sessions/{username}/SESSION_NOTES.md and continue where we left off."
 
+## Connection Troubleshooting
+
+If tool calls fail or the bridge seems unreachable, run the doctor from a terminal:
+
+\`\`\`bash
+npx @mosaicxr-ai/mcp-server doctor --project-path <this Unity project>
+\`\`\`
+
+It checks the discovery file, live editor, port, HMAC handshake, and clock skew, and prints
+exactly which link is broken. The usual cause: the Unity Editor isn't open, or it's still compiling.
+With one Editor open you can omit \`--project-path\` — it auto-detects.
+
+## Workflow Prompts (MCP)
+
+This bridge also exposes its protocols as MCP prompts — \`preflight\`, \`scene-interview\`,
+\`session-handoff\`, and \`shader-guide\`. Invoke them from your client's prompt menu (in Claude Code,
+the prompt picker) when you want the full protocol text on demand.
+
 ## When in Doubt
 
 Ask a clarifying question rather than guessing. A 2-minute interview prevents a 20-minute rebuild.

--- a/packages/create-bridge/test/install-workflows.test.js
+++ b/packages/create-bridge/test/install-workflows.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readdirSync,
+  writeFileSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { copyDirSync } from '../src/utils.js';
+
+const PKG_DIR = path.resolve(fileURLToPath(import.meta.url), '../..');
+const PLUGIN = path.join(PKG_DIR, 'plugin');
+const BIN = path.join(PKG_DIR, 'bin', 'create-bridge.js');
+
+let tmp;
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+  tmp = undefined;
+});
+
+describe('workflow installation', () => {
+  it('copyDirSync brings the workflow set across', () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'mosaic-'));
+    const dst = path.join(tmp, '.claude', 'workflows');
+    copyDirSync(path.join(PLUGIN, 'workflows'), dst);
+    expect(existsSync(dst)).toBe(true);
+    const dirs = readdirSync(dst);
+    expect(dirs).toEqual(
+      expect.arrayContaining(['preflight', 'scene-plan', 'shader-guide', 'session-handoff'])
+    );
+  });
+
+  it('the installer writes skills and workflows into the project', () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'mosaic-proj-'));
+    // Make it look like a Unity project so validation passes.
+    mkdirSync(path.join(tmp, 'Assets'), { recursive: true });
+    mkdirSync(path.join(tmp, 'ProjectSettings'), { recursive: true });
+    writeFileSync(
+      path.join(tmp, 'ProjectSettings', 'ProjectVersion.txt'),
+      'm_EditorVersion: 2022.3.50f1\n'
+    );
+
+    execFileSync(
+      process.execPath,
+      [BIN, '--project-path', tmp, '--yes', '--skip-unity', '--skip-clients', '--skip-claude'],
+      { encoding: 'utf8' }
+    );
+
+    expect(existsSync(path.join(tmp, '.claude', 'skills', 'mosaic-guide'))).toBe(true);
+    expect(existsSync(path.join(tmp, '.agents', 'skills', 'mosaic-guide'))).toBe(true);
+    expect(existsSync(path.join(tmp, '.claude', 'workflows', 'preflight'))).toBe(true);
+  });
+});

--- a/packages/create-bridge/test/smoke.test.js
+++ b/packages/create-bridge/test/smoke.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import pkg from '../package.json' with { type: 'json' };
+
+describe('create-bridge test harness', () => {
+  it('loads package.json and sees the published version', () => {
+    expect(pkg.name).toBe('@mosaicxr-ai/create-bridge');
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/packages/create-bridge/test/tarball-contents.test.js
+++ b/packages/create-bridge/test/tarball-contents.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const pkgDir = path.resolve(fileURLToPath(import.meta.url), '../..');
+
+function packedFiles() {
+  const out = execFileSync('npm', ['pack', '--dry-run', '--json'], {
+    cwd: pkgDir,
+    encoding: 'utf8',
+  });
+  return JSON.parse(out)[0].files.map((f) => f.path);
+}
+
+describe('published tarball', () => {
+  const files = packedFiles();
+
+  it('includes the full plugin: agents, commands, and .claude-plugin manifest', () => {
+    expect(files.some((f) => f.startsWith('plugin/agents/'))).toBe(true);
+    expect(files.some((f) => f.startsWith('plugin/commands/'))).toBe(true);
+    expect(files.some((f) => f === 'plugin/.claude-plugin/plugin.json')).toBe(true);
+  });
+
+  it('still includes skills and workflows', () => {
+    expect(files.some((f) => f.startsWith('plugin/skills/'))).toBe(true);
+    expect(files.some((f) => f.startsWith('plugin/workflows/'))).toBe(true);
+  });
+});

--- a/packages/create-bridge/test/version.test.js
+++ b/packages/create-bridge/test/version.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { VERSION } from '../src/cli.js';
+
+const pkg = JSON.parse(
+  readFileSync(path.resolve(fileURLToPath(import.meta.url), '../../package.json'), 'utf8')
+);
+
+describe('create-bridge --version', () => {
+  it('reports the version from package.json, not a hardcoded string', () => {
+    expect(VERSION).toBe(pkg.version);
+  });
+});

--- a/packages/create-bridge/vitest.config.js
+++ b/packages/create-bridge/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.js'],
+    environment: 'node',
+  },
+});

--- a/packages/mcp-server/CHANGELOG.md
+++ b/packages/mcp-server/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this package will be documented in this file.
 
+## [1.0.0-beta.7] — 2026-07-12
+
+### Added
+
+- **`doctor` command** — `mosaic-mcp doctor [--project-path <path>]` runs connection
+  diagnostics and prints a copy-pasteable report: discovery file (found/parsed/signed),
+  live Unity Editor detection, TCP port reachability, a signed health + HMAC handshake,
+  and clock-skew detection. Exits non-zero when any check fails. Replaces the opaque
+  "Connection closed" failure that gave users nothing to act on.
+- **MCP prompts capability** — the Mosaic Bridge workflow rules are now exposed over the
+  protocol via `prompts/list` and `prompts/get`: `preflight`, `scene-interview`,
+  `session-handoff`, and `shader-guide`. Every MCP client receives them, not just clients
+  whose installer wrote a `CLAUDE.md`/`GEMINI.md`/`AGENTS.md`.
+
+### Fixed
+
+- **Version reporting** — `--version` now prints the real package version (was a
+  placeholder string), and the MCP handshake advertises the real version instead of a
+  hardcoded `1.0.0`. Both read from `package.json` at runtime.
+
+---
+
 ## [1.0.0-beta.6] — 2026-04-29
 
 ### Added

--- a/packages/mcp-server/package-lock.json
+++ b/packages/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mosaicxr-ai/mcp-server",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mosaicxr-ai/mcp-server",
-      "version": "1.0.0-beta.6",
+      "version": "1.0.0-beta.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mosaicxr-ai/mcp-server",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "description": "MCP server for Mosaic Bridge — connects AI clients (Claude Desktop, Cursor, etc.) to the Unity Editor.",
   "license": "Apache-2.0",
   "author": {

--- a/packages/mcp-server/src/doctor.ts
+++ b/packages/mcp-server/src/doctor.ts
@@ -1,0 +1,196 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { createConnection } from 'node:net';
+import {
+  resolveDiscoveryFilePath,
+  readInstanceRegistry,
+  type DiscoveryOptions,
+} from './discovery.js';
+import { BridgeClient } from './bridge-client.js';
+import type { DiscoveryData } from './types.js';
+
+export type CheckStatus = 'pass' | 'warn' | 'fail';
+
+export interface DoctorCheck {
+  name: string;
+  status: CheckStatus;
+  detail: string;
+}
+
+export interface DoctorReport {
+  checks: DoctorCheck[];
+  /** True when no check failed. Warnings do not flip this to false. */
+  ok: boolean;
+}
+
+/** How far in the future the discovery file's mtime may sit before we warn about clock skew. */
+const CLOCK_SKEW_WARN_MS = 5 * 60 * 1000;
+
+/**
+ * Runs a sequence of connection diagnostics and returns a structured report.
+ * Never throws: every check is fault-isolated into a {name, status, detail} record,
+ * so a failure early in the chain still produces a full, readable report.
+ */
+export async function runDoctor(opts: DiscoveryOptions = {}): Promise<DoctorReport> {
+  const checks: DoctorCheck[] = [];
+
+  // 1. Discovery file — resolve, exist, parse, schema, signature.
+  let discovery: DiscoveryData | undefined;
+  let discoveryPath: string | undefined;
+  try {
+    discoveryPath = resolveDiscoveryFilePath(opts);
+    if (!existsSync(discoveryPath)) {
+      checks.push({
+        name: 'Discovery file',
+        status: 'fail',
+        detail: `Not found at ${discoveryPath}. Is the Unity Editor running with Mosaic Bridge installed?`,
+      });
+    } else {
+      const raw = readFileSync(discoveryPath, 'utf8').replace(/^\uFEFF/, '');
+      const data = JSON.parse(raw) as DiscoveryData;
+      if (!data.schema_version?.startsWith('1.')) {
+        checks.push({
+          name: 'Discovery file',
+          status: 'fail',
+          detail: `Unsupported schema_version "${data.schema_version}" at ${discoveryPath}.`,
+        });
+      } else if (!data.signature) {
+        discovery = data;
+        checks.push({
+          name: 'Discovery file',
+          status: 'warn',
+          detail: `Found (${discoveryPath}) but unsigned. Upgrade the Unity bridge to v1.2+ for integrity verification.`,
+        });
+      } else {
+        discovery = data;
+        checks.push({
+          name: 'Discovery file',
+          status: 'pass',
+          detail: `Found and signed (${discoveryPath}), Unity ${data.unity_version}, port ${data.port}.`,
+        });
+      }
+    }
+  } catch (err) {
+    checks.push({
+      name: 'Discovery file',
+      status: 'fail',
+      detail: message(err),
+    });
+  }
+
+  // 2. Live editor — instance registry filtered to running PIDs.
+  try {
+    const alive = readInstanceRegistry().filter((e) => isProcessAlive(e.pid));
+    if (alive.length === 1) {
+      checks.push({
+        name: 'Live editor',
+        status: 'pass',
+        detail: `1 running Unity Editor (pid ${alive[0].pid}, port ${alive[0].port}).`,
+      });
+    } else if (alive.length === 0) {
+      checks.push({
+        name: 'Live editor',
+        status: 'warn',
+        detail: 'No running Unity Editor found in the instance registry. If the bridge is running, this is harmless.',
+      });
+    } else {
+      checks.push({
+        name: 'Live editor',
+        status: 'warn',
+        detail: `${alive.length} running editors — pass --project-path <path> so the server targets the right one.`,
+      });
+    }
+  } catch (err) {
+    checks.push({ name: 'Live editor', status: 'warn', detail: message(err) });
+  }
+
+  // 3. Port reachable — TCP connect to 127.0.0.1:<port>.
+  if (discovery?.port) {
+    const reachable = await isPortReachable(discovery.port);
+    checks.push(
+      reachable
+        ? { name: 'Port reachable', status: 'pass', detail: `127.0.0.1:${discovery.port} accepted a connection.` }
+        : { name: 'Port reachable', status: 'fail', detail: `Nothing listening on 127.0.0.1:${discovery.port}. The bridge may be stopped or on a different port.` }
+    );
+  } else {
+    checks.push({ name: 'Port reachable', status: 'warn', detail: 'Skipped — no port from discovery.' });
+  }
+
+  // 4. Health + HMAC — a signed request that exercises the shared secret.
+  if (discovery?.port && discovery?.secret_base64) {
+    try {
+      const client = new BridgeClient(discovery.port, discovery.secret_base64);
+      const health = await client.health();
+      checks.push(
+        health.status === 'ok'
+          ? { name: 'Health + HMAC', status: 'pass', detail: `Bridge healthy — ${health.tool_count} tools, state ${health.bridge_state}.` }
+          : { name: 'Health + HMAC', status: 'fail', detail: `Bridge health returned status "${health.status}".` }
+      );
+    } catch (err) {
+      const m = message(err);
+      const hint = m.includes('401')
+        ? ' HMAC secret mismatch — the bridge likely rotated it on a domain reload. Restart the MCP client.'
+        : '';
+      checks.push({ name: 'Health + HMAC', status: 'fail', detail: m + hint });
+    }
+  } else {
+    checks.push({ name: 'Health + HMAC', status: 'warn', detail: 'Skipped — no port/secret from discovery.' });
+  }
+
+  // 5. Clock skew — discovery file written far in the future means the local clock lags,
+  //    which can trip the bridge's HMAC timestamp window.
+  if (discoveryPath && existsSync(discoveryPath)) {
+    try {
+      const mtimeMs = statSync(discoveryPath).mtimeMs;
+      const skew = mtimeMs - Date.now();
+      checks.push(
+        skew > CLOCK_SKEW_WARN_MS
+          ? { name: 'Clock skew', status: 'warn', detail: `Discovery file mtime is ${Math.round(skew / 1000)}s ahead of this machine — a large clock gap can cause HMAC timestamp rejections.` }
+          : { name: 'Clock skew', status: 'pass', detail: 'System clock within tolerance of the bridge host.' }
+      );
+    } catch (err) {
+      checks.push({ name: 'Clock skew', status: 'warn', detail: message(err) });
+    }
+  }
+
+  return { checks, ok: checks.every((c) => c.status !== 'fail') };
+}
+
+/** Renders a report as a human-readable, copy-pasteable block. */
+export function formatDoctorReport(r: DoctorReport): string {
+  const glyph: Record<CheckStatus, string> = { pass: '✓', warn: '⚠', fail: '✗' };
+  const lines = ['Mosaic Bridge — connection doctor', ''];
+  for (const c of r.checks) {
+    lines.push(`  ${glyph[c.status]} ${c.name}: ${c.detail}`);
+  }
+  lines.push('');
+  lines.push(r.ok ? 'Result: OK — the bridge is reachable.' : 'Result: PROBLEMS FOUND — see the ✗ lines above.');
+  lines.push('');
+  return lines.join('\n');
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isPortReachable(port: number, host = '127.0.0.1', timeoutMs = 2000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ port, host });
+    const done = (ok: boolean) => {
+      socket.destroy();
+      resolve(ok);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => done(true));
+    socket.once('timeout', () => done(false));
+    socket.once('error', () => done(false));
+  });
+}
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -4,6 +4,7 @@ import { readDiscovery, type DiscoveryOptions } from './discovery.js';
 import { BridgeClient } from './bridge-client.js';
 import { createMosaicServer } from './server.js';
 import { getVersion } from './version.js';
+import { runDoctor, formatDoctorReport } from './doctor.js';
 
 /**
  * Parses CLI arguments. Supports:
@@ -13,11 +14,15 @@ import { getVersion } from './version.js';
  *   --help                  Show usage and exit
  *   --version               Show version and exit
  */
-function parseArgs(argv: string[]): DiscoveryOptions & { help?: boolean; version?: boolean } {
-  const opts: DiscoveryOptions & { help?: boolean; version?: boolean } = {};
+function parseArgs(argv: string[]): DiscoveryOptions & { help?: boolean; version?: boolean; doctor?: boolean } {
+  const opts: DiscoveryOptions & { help?: boolean; version?: boolean; doctor?: boolean } = {};
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     switch (arg) {
+      case 'doctor':             // Subcommand: run connection diagnostics and exit
+      case '--doctor':
+        opts.doctor = true;
+        break;
       case '--project-path':
         opts.projectPath = argv[++i];
         break;
@@ -50,6 +55,7 @@ function printUsage(): void {
     '',
     'Usage:',
     '  mosaic-mcp [options]',
+    '  mosaic-mcp doctor [options]   Diagnose the connection to the Unity bridge and exit.',
     '',
     'Options:',
     '  --project-path <path>   Path to Unity project root or its Assets directory.',
@@ -87,6 +93,16 @@ async function main() {
   if (opts.version) {
     process.stdout.write(`mosaic-mcp ${getVersion()}\n`);
     process.exit(0);
+  }
+  if (opts.doctor) {
+    const report = await runDoctor({
+      projectPath: opts.projectPath,
+      projectHash: opts.projectHash,
+      runtimeDir: opts.runtimeDir,
+      discoveryFile: opts.discoveryFile,
+    });
+    process.stdout.write(formatDoctorReport(report));
+    process.exit(report.ok ? 0 : 1);
   }
 
   // 1. Read discovery file (with project-aware routing).

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { readDiscovery, type DiscoveryOptions } from './discovery.js';
 import { BridgeClient } from './bridge-client.js';
 import { createMosaicServer } from './server.js';
+import { getVersion } from './version.js';
 
 /**
  * Parses CLI arguments. Supports:
@@ -84,8 +85,7 @@ async function main() {
     process.exit(0);
   }
   if (opts.version) {
-    // Emit a simple version line. The real version is in package.json.
-    process.stdout.write('mosaic-mcp (see package.json for version)\n');
+    process.stdout.write(`mosaic-mcp ${getVersion()}\n`);
     process.exit(0);
   }
 
@@ -118,6 +118,7 @@ async function main() {
     client,
     discovery,
     initialTools: tools,
+    version: getVersion(),
   });
 
   // 5. Start serving over stdio.

--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -1,0 +1,123 @@
+/**
+ * MCP prompts — the Mosaic Bridge workflow rules, exposed over the protocol so
+ * every client receives them, not only clients whose installer wrote a
+ * CLAUDE.md/GEMINI.md/AGENTS.md instruction file.
+ *
+ * The text below is the canonical protocol content, kept in lockstep with the
+ * shared `BASE_INSTRUCTIONS` block in `create-bridge/src/templates.js`. If you
+ * edit one, edit the other.
+ */
+
+export interface McpPromptDef {
+  name: string;
+  description: string;
+  arguments?: { name: string; description: string; required: boolean }[];
+  build(args: Record<string, string>): string;
+}
+
+const SCENE_INTERVIEW = `## Scene Building — Interview Protocol
+
+When asked to "build a scene", "create an environment", or describe any vague place/mood:
+
+STOP. Do not call any Mosaic tools. Run the Scene Interview first.
+
+Ask all four Tier 1 questions in a single message:
+
+1. Scene type? — game level / playable · cinematic · archviz · prototype
+2. Geographic or thematic reference? — be specific: "Wadi Rum Jordan", "Pacific Northwest forest", "dystopian 2080 Tokyo". Generic = generic output.
+3. Scale? — < 100m · 100m–1km · 1–10km · 10km+
+4. Player perspective? — first person · third person · drone / flight · top-down · no player (cinematic only)
+
+After the interview, generate a ScenePlan summary and wait for confirmation before executing any tools.
+
+## Spatial Coherence Contract
+
+Every placed object Y must = terrain.SampleHeight(x, z) + small_offset. Never use Y=0 as a placement
+coordinate unless the scene is a flat indoor space. Call terrain/sample-height before every
+gameobject/create or prefab/instantiate.
+
+## Execution Pipeline Order
+
+Always build in this order (skipping creates visual artifacts):
+1. Terrain — create, sculpt major features, secondary detail
+2. Water — if applicable; sets the shoreline Y reference
+3. Terrain textures — layer setup + splatmap painting
+4. Sky + Lighting — directional light, skybox, ambient
+5. Large structures — buildings, rock formations (use terrain/sample-height for Y)
+6. Vegetation — trees (terrain system) then grass then small details
+7. Post-processing — fog, bloom, color grade (last pass)
+8. Camera / player controller — calibrated to final scene scale`;
+
+const PREFLIGHT = `## Session Start Protocol
+
+Always call project/preflight at the start of each session:
+  { "tool": "project/preflight" }
+
+The result includes:
+- RenderPipeline — the active pipeline (URP / HDRP / BuiltIn) materials resolve against
+- ColorProperty — _BaseColor (URP/HDRP) or _Color (BuiltIn)
+- GraphicsPipelineAsset — project default (Project Settings → Graphics)
+- QualityPipelineAsset — per-quality-level override (Project Settings → Quality → Rendering)
+- PipelineMismatch — true when the Quality override differs from the Graphics default. If true, the
+  Quality asset wins for the active quality level. Read both before creating materials, or materials
+  may render magenta on platforms with different quality presets.
+- InputSystem — Legacy / New / Both (active input handling)
+- InputSystemPackageInstalled — whether com.unity.inputsystem is in the manifest
+
+Never assume the pipeline — always verify it first.
+
+## Render Pipeline Quick Reference
+
+| Pipeline | Default Shader                   | Color Property |
+|----------|----------------------------------|----------------|
+| URP      | Universal Render Pipeline/Lit    | _BaseColor     |
+| HDRP     | HDRP/Lit                         | _BaseColor     |
+| BuiltIn  | Standard                         | _Color         |
+
+Magenta material = wrong shader for pipeline. Use material/create without ShaderName to auto-detect.`;
+
+const SHADER_GUIDE = `## ShaderGraph Serialization Rules (Unity 14.x+)
+
+These rules are enforced automatically by the tools — no manual workarounds needed:
+
+| Rule                 | Detail                                                             |
+|----------------------|--------------------------------------------------------------------|
+| UUID GUIDs           | m_ObjectId format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx             |
+| VoronoiNode          | Requires SGVersion=1 + m_HashType=0                                |
+| Texture slots        | StageCapability=2 (fragment-only)                                  |
+| CustomFunction       | SGVersion=1 + m_SourceType=1 for inline HLSL                       |
+| Block-based contexts | Unity 14.x+ uses m_VertexContext / m_FragmentContext — no PBRMaster |
+
+Workflow: shadergraph/create → shadergraph/add-node → shadergraph/connect.
+Do not fall back to raw HLSL .shader files when a ShaderGraph will do.`;
+
+const SESSION_HANDOFF = `## Session Handoff
+
+At the end of every session (or when context is running low), write a handoff:
+- Path: docs/Sessions/{username}/SESSION_NOTES.md
+- Include: pipeline, color property, assets created, errors encountered, remaining work
+- Recovery prompt: "Load session notes from docs/Sessions/{username}/SESSION_NOTES.md and continue
+  where we left off."`;
+
+export const MOSAIC_PROMPTS: McpPromptDef[] = [
+  {
+    name: 'preflight',
+    description: 'Run project/preflight and interpret the render pipeline, packages, and input system at session start.',
+    build: () => PREFLIGHT,
+  },
+  {
+    name: 'scene-interview',
+    description: 'The interview protocol to run before building any scene — questions, ScenePlan, spatial-coherence contract, and build order.',
+    build: () => SCENE_INTERVIEW,
+  },
+  {
+    name: 'session-handoff',
+    description: 'Write docs/Sessions/{username}/SESSION_NOTES.md before ending a session so the next one can resume.',
+    build: () => SESSION_HANDOFF,
+  },
+  {
+    name: 'shader-guide',
+    description: 'ShaderGraph serialization + node-wiring rules for Unity 14.x+.',
+    build: () => SHADER_GUIDE,
+  },
+];

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -4,12 +4,15 @@ import {
   ListToolsRequestSchema,
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
   McpError,
   ErrorCode,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { BridgeTool, BridgeToolResult, HealthResponse, KbEntry, KbReadResult, DiscoveryData } from './types.js';
 import { DomainReloadError } from './bridge-client.js';
 import { getVersion } from './version.js';
+import { MOSAIC_PROMPTS } from './prompts.js';
 
 // Story 3.4: Map bridge error codes to JSON-RPC error codes
 const ERROR_CODE_MAP: Record<string, number> = {
@@ -61,6 +64,7 @@ export function createMosaicServer(opts: CreateServerOptions): Server {
       capabilities: {
         tools: {},
         resources: {},
+        prompts: {},
       },
     }
   );
@@ -341,6 +345,29 @@ export function createMosaicServer(opts: CreateServerOptions): Server {
     }
 
     throw new McpError(ErrorCode.InvalidRequest, `Unknown resource: ${uri}`);
+  });
+
+  // Handle prompts/list — the Mosaic Bridge workflow rules as MCP prompts.
+  server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+    prompts: MOSAIC_PROMPTS.map(p => ({
+      name: p.name,
+      description: p.description,
+      arguments: p.arguments ?? [],
+    })),
+  }));
+
+  // Handle prompts/get — render a single prompt as a user message.
+  server.setRequestHandler(GetPromptRequestSchema, async (req) => {
+    const def = MOSAIC_PROMPTS.find(p => p.name === req.params.name);
+    if (!def) {
+      throw new McpError(ErrorCode.InvalidRequest, `Unknown prompt: ${req.params.name}`);
+    }
+    return {
+      messages: [{
+        role: 'user' as const,
+        content: { type: 'text' as const, text: def.build(req.params.arguments ?? {}) },
+      }],
+    };
   });
 
   return server;

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -9,6 +9,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import type { BridgeTool, BridgeToolResult, HealthResponse, KbEntry, KbReadResult, DiscoveryData } from './types.js';
 import { DomainReloadError } from './bridge-client.js';
+import { getVersion } from './version.js';
 
 // Story 3.4: Map bridge error codes to JSON-RPC error codes
 const ERROR_CODE_MAP: Record<string, number> = {
@@ -42,6 +43,8 @@ export interface CreateServerOptions {
   client: IBridgeClient;
   discovery: Pick<DiscoveryData, 'port' | 'unity_version' | 'unity_project_path'>;
   initialTools: BridgeTool[];
+  /** Server version advertised in the MCP handshake. Defaults to the package version. */
+  version?: string;
 }
 
 /**
@@ -53,7 +56,7 @@ export function createMosaicServer(opts: CreateServerOptions): Server {
   let tools: BridgeTool[] = opts.initialTools;
 
   const server = new Server(
-    { name: 'mosaic-bridge', version: '1.0.0' },
+    { name: 'mosaic-bridge', version: opts.version ?? getVersion() },
     {
       capabilities: {
         tools: {},

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * Reads the real package version from package.json at runtime.
+ * `../../package.json` resolves to the package root from both `src/version.ts`
+ * (dev/test) and the compiled `dist/version.js` — each is one level under root.
+ */
+export function getVersion(): string {
+  const pkgPath = path.resolve(fileURLToPath(import.meta.url), '../../package.json');
+  return JSON.parse(readFileSync(pkgPath, 'utf8')).version;
+}

--- a/packages/mcp-server/tests/conformance.test.ts
+++ b/packages/mcp-server/tests/conformance.test.ts
@@ -15,6 +15,7 @@ import {
   type TestHarness,
 } from './helpers.js';
 import type { BridgeToolResult } from '../src/types.js';
+import { getVersion } from '../src/version.js';
 
 // ==========================================================================
 // 1. Protocol Handshake
@@ -31,7 +32,9 @@ describe('Protocol Handshake', () => {
     const info = h.client.getServerVersion();
     expect(info).toBeDefined();
     expect(info?.name).toBe('mosaic-bridge');
-    expect(info?.version).toBe('1.0.0');
+    // The harness passes no explicit version, so the server defaults to the
+    // real package version — assert it reports that, not the old hardcoded string.
+    expect(info?.version).toBe(getVersion());
   });
 
   it('server declares tools capability', () => {

--- a/packages/mcp-server/tests/doctor.test.ts
+++ b/packages/mcp-server/tests/doctor.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { runDoctor, formatDoctorReport } from '../src/doctor.js';
+
+let tmp: string | undefined;
+afterEach(() => {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+  tmp = undefined;
+});
+
+describe('runDoctor', () => {
+  it('fails the discovery check when the file is missing', async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'mosaic-doctor-'));
+    const report = await runDoctor({ runtimeDir: tmp });
+    const discovery = report.checks.find((c) => c.name === 'Discovery file');
+    expect(discovery?.status).toBe('fail');
+    expect(report.ok).toBe(false);
+  });
+
+  it('fails the port check when a discovery file points at a dead port', async () => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'mosaic-doctor-'));
+    // Port 1 is privileged and unbound in test — connect refuses immediately.
+    writeFileSync(
+      path.join(tmp, 'bridge-discovery.json'),
+      JSON.stringify({
+        schema_version: '1.0',
+        port: 1,
+        process_id: 999999,
+        started_unix_seconds: Math.floor(Date.now() / 1000),
+        secret_base64: Buffer.from('test-secret').toString('base64'),
+        unity_project_path: '/tmp/fake',
+        unity_version: '2022.3.50f1',
+      })
+    );
+    const report = await runDoctor({ runtimeDir: tmp });
+    const discovery = report.checks.find((c) => c.name === 'Discovery file');
+    const port = report.checks.find((c) => c.name === 'Port reachable');
+    expect(discovery?.status).toBe('warn'); // present but unsigned
+    expect(port?.status).toBe('fail');
+    expect(report.ok).toBe(false);
+  });
+
+  it('never throws — always returns a full report', async () => {
+    const report = await runDoctor({ runtimeDir: '/nonexistent/does/not/exist' });
+    expect(Array.isArray(report.checks)).toBe(true);
+    expect(report.checks.length).toBeGreaterThan(0);
+  });
+});
+
+describe('formatDoctorReport', () => {
+  it('renders one glyph-prefixed line per check and a result line', () => {
+    const text = formatDoctorReport({
+      checks: [
+        { name: 'Discovery file', status: 'pass', detail: 'ok' },
+        { name: 'Port reachable', status: 'fail', detail: 'refused' },
+      ],
+      ok: false,
+    });
+    expect(text).toContain('✓ Discovery file');
+    expect(text).toContain('✗ Port reachable');
+    expect(text).toContain('PROBLEMS FOUND');
+  });
+});

--- a/packages/mcp-server/tests/prompts.test.ts
+++ b/packages/mcp-server/tests/prompts.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { MOSAIC_PROMPTS } from '../src/prompts.js';
+import { createTestHarness, type TestHarness } from './helpers.js';
+
+describe('MCP prompt definitions', () => {
+  it('exposes the four workflow prompts', () => {
+    const names = MOSAIC_PROMPTS.map((p) => p.name).sort();
+    expect(names).toEqual(['preflight', 'scene-interview', 'session-handoff', 'shader-guide']);
+  });
+
+  it('scene-interview builds non-empty guidance text', () => {
+    const p = MOSAIC_PROMPTS.find((p) => p.name === 'scene-interview')!;
+    const text = p.build({});
+    expect(text).toMatch(/interview/i);
+    expect(text.length).toBeGreaterThan(200);
+  });
+});
+
+describe('Prompts Protocol (through the server)', () => {
+  let h: TestHarness;
+  beforeAll(async () => {
+    h = await createTestHarness();
+  });
+  afterAll(async () => {
+    await h.cleanup();
+  });
+
+  it('declares the prompts capability', () => {
+    const caps = h.client.getServerCapabilities();
+    expect(caps?.prompts).toBeDefined();
+  });
+
+  it('prompts/list returns all four prompts', async () => {
+    const res = await h.client.listPrompts();
+    expect(res.prompts.map((p) => p.name).sort()).toEqual([
+      'preflight',
+      'scene-interview',
+      'session-handoff',
+      'shader-guide',
+    ]);
+  });
+
+  it('prompts/get returns a text message for a known prompt', async () => {
+    const res = await h.client.getPrompt({ name: 'preflight' });
+    expect(res.messages).toHaveLength(1);
+    expect(res.messages[0].role).toBe('user');
+    const content = res.messages[0].content;
+    expect(content.type).toBe('text');
+    expect((content as { text: string }).text).toMatch(/preflight/i);
+  });
+
+  it('prompts/get rejects an unknown prompt', async () => {
+    await expect(h.client.getPrompt({ name: 'does-not-exist' })).rejects.toThrow();
+  });
+});

--- a/packages/mcp-server/tests/version.test.ts
+++ b/packages/mcp-server/tests/version.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { getVersion } from '../src/version.js';
+
+const pkg = JSON.parse(
+  readFileSync(path.resolve(fileURLToPath(import.meta.url), '../../package.json'), 'utf8')
+);
+
+describe('mosaic-mcp getVersion()', () => {
+  it('returns the package.json version, not a hardcoded string', () => {
+    expect(getVersion()).toBe(pkg.version);
+    expect(getVersion()).not.toBe('1.0.0');
+  });
+});


### PR DESCRIPTION
## Summary

Ships all four **Wave 0 (P0)** items from the free-bridge roadmap — the "unlock value already built" fixes — plus supporting docs. Full plan: \`docs/superpowers/plans/2026-07-12-free-bridge-roadmap.md\`.

## What's included

- **Version reporting fix** — \`create-bridge\` was stuck reporting \`beta.4\` and \`mcp-server --version\` printed a placeholder; both now read the real version from \`package.json\`, and the MCP handshake advertises it (was hardcoded \`1.0.0\`).
- **Full plugin in the npm tarball + workflow install** — the \`files\` allowlist excluded \`plugin/agents\`, \`plugin/commands\`, and the \`.claude-plugin\` manifest, so the Zara/Ray/Max agents never shipped. Workflows shipped but were never copied into projects. Both fixed.
- **MCP prompts capability** — \`prompts/list\` + \`prompts/get\` expose \`preflight\`, \`scene-interview\`, \`session-handoff\`, \`shader-guide\` to every client.
- **\`doctor\` command** — \`mosaic-mcp doctor\` runs five fault-isolated connection checks and prints a copy-pasteable report; exits non-zero on failure. Verified live against a running bridge (Unity 6000.3.10f1, 265 tools).
- **Docs** — new \`TESTING.md\`; README gains a Troubleshooting section built around \`doctor\`, a corrected tool count (290 across 64 categories), and prompt/workflow documentation.
- **Test harness** — new vitest suite for \`create-bridge\`.

## Testing

- \`mcp-server\`: 54 tests pass (\`npm test\`), build clean.
- \`create-bridge\`: 6 tests pass (\`npm test\`).
- \`doctor\` validated end-to-end against a live bridge — all five checks green.

## Versions

- \`@mosaicxr-ai/mcp-server\` → \`1.0.0-beta.7\`
- \`@mosaicxr-ai/create-bridge\` → \`1.0.0-beta.8\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)