### PR TITLE
docs: align tool count to ~290 everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Mosaic Bridge connects MCP-compliant AI clients — Claude Code, Claude Desktop,
 Cursor, Gemini CLI, and any other Model Context Protocol client — to a running
-Unity Editor. It exposes 290 tools covering GameObject and scene operations,
+Unity Editor. It exposes ~290 tools covering GameObject and scene operations,
 procedural generation, physics simulation, pathfinding, rendering, animation,
 and more.
 
@@ -191,7 +191,7 @@ Then point your MCP client at:
 
 ## What's inside
 
-290 tools across 64 categories. A sample:
+~290 tools across 64 categories. A sample:
 
 | Category | Tools | Notable |
 |---|---|---|
@@ -416,7 +416,7 @@ Monorepo layout:
 ```
 packages/
 ├── com.mosaic.bridge/       Unity UPM package (Editor + Runtime + Tests)
-│   ├── Editor/              290 tools + core infrastructure
+│   ├── Editor/              ~290 tools + core infrastructure
 │   ├── Runtime/             Runtime-compatible tool subset
 │   ├── Tests/               NUnit + Unity Test Runner
 │   └── Samples~/            Custom-tool authoring sample
@@ -437,7 +437,7 @@ project's `manifest.json`:
 ## Roadmap
 
 ### v1.0 beta (current)
-- Core bridge, MCP server, 290 tools across 64 categories
+- Core bridge, MCP server, ~290 tools across 64 categories
 - Per-project runtime isolation
 - Auto `.mcp.json` for Claude Code + auto-config for Claude Desktop, Cursor,
   Gemini CLI, and OpenAI Codex CLI via `npx @mosaicxr-ai/create-bridge`


### PR DESCRIPTION
Makes the tool count consistent across the README (was `290`, now `~290`) to match the corrected GitHub repo description (was `~200`, now `~290`). Prevents a launch-day "these numbers don't match" nitpick.

Note: a fresh URP project registers ~265 tools live; the full ~290 is the source set — package-integration tools (HDRP/ProBuilder/Cinemachine/etc.) register only when their Unity package is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)